### PR TITLE
Replace public lists with iterables in providers

### DIFF
--- a/togetherly/lib/providers/README.md
+++ b/togetherly/lib/providers/README.md
@@ -132,7 +132,7 @@ its results should instead be treated as part of the state.
 
 BAD example:
 ```dart
-Future<List<Thing>> searchForThings(string query) async {
+Future<Iterable<Thing>> searchForThings(string query) async {
   ...
   return resultSet;
 }
@@ -144,7 +144,7 @@ string? _currentQuery;
 string? currentQuery get => _currentQuery;
 
 List<Thing>? _currentSearchResults;
-List<Thing>? currentSearchResults get => _currentSearchResults;
+Iterable<Thing>? currentSearchResults get => _currentSearchResults;
 
 Future<void> updateQuery(string query) async {
   _currentQuery = query;

--- a/togetherly/lib/providers/chore_provider.dart
+++ b/togetherly/lib/providers/chore_provider.dart
@@ -24,10 +24,10 @@ class ChoreProvider with ChangeNotifier {
   UserIdentityProvider _userIdentityProvider;
 
   List<Chore> _allChores = [];
-  List<Chore> get allChores => _allChores;
+  Iterable<Chore> get allChores => _allChores;
 
   List<Assignment> _allAssignments = [];
-  List<Assignment> get allAssignments => _allAssignments;
+  Iterable<Assignment> get allAssignments => _allAssignments;
 
   /// Cached copy of [_choreIdToPersonIds].
   Map<int, Set<int>>? _choreIdToPersonIdsCache;
@@ -64,7 +64,7 @@ class ChoreProvider with ChangeNotifier {
               (a) => a.choreId == chore.id && a.personId == personId)
           ?.status;
 
-  Future<void> addChore(Chore chore, [List<int>? assignedChildIds]) async {
+  Future<void> addChore(Chore chore, [Iterable<int>? assignedChildIds]) async {
     final familyId = _userIdentityProvider.familyId;
     if (familyId != null) {
       final newChoreId = (await _choreService.insertChore(familyId, chore)).id;
@@ -90,7 +90,8 @@ class ChoreProvider with ChangeNotifier {
     await refresh();
   }
 
-  Future<void> updateChore(Chore chore, [List<int>? assignedChildIds]) async {
+  Future<void> updateChore(Chore chore,
+      [Iterable<int>? assignedChildIds]) async {
     await _choreService.updateChore(chore);
     if (assignedChildIds != null) {
       await updateChildrenAssignedToChore(chore, assignedChildIds);
@@ -117,7 +118,7 @@ class ChoreProvider with ChangeNotifier {
   }
 
   Future<void> updateChildrenAssignedToChore(
-      Chore chore, List<int> assignedChildIds) async {
+      Chore chore, Iterable<int> assignedChildIds) async {
     final choreId = chore.id!;
     Set<int> previous = personIdsAssignedToChore(chore).toSet();
     Set<int> updated = assignedChildIds.toSet();

--- a/togetherly/lib/providers/person_provider.dart
+++ b/togetherly/lib/providers/person_provider.dart
@@ -17,10 +17,10 @@ class PersonProvider with ChangeNotifier {
   UserIdentityProvider _userIdentityProvider;
 
   List<Parent> _parents = [];
-  List<Parent> get parents => _parents;
+  Iterable<Parent> get parents => _parents;
 
   List<Child> _children = [];
-  List<Child> get children => _children;
+  Iterable<Child> get children => _children;
 
   Future<void> addPerson(Person person) async {
     final familyId = _userIdentityProvider.familyId;

--- a/togetherly/lib/providers/reward_provider.dart
+++ b/togetherly/lib/providers/reward_provider.dart
@@ -16,7 +16,7 @@ class RewardProvider with ChangeNotifier {
   UserIdentityProvider _userIdentityProvider;
 
   List<Reward> _rewards = [];
-  List<Reward> get rewards => _rewards;
+  Iterable<Reward> get rewards => _rewards;
 
   Future<void> addReward(Reward reward) async {
     final familyId = _userIdentityProvider.familyId;


### PR DESCRIPTION
This PR replaces `List` with `Iterable` on any public getters or methods that Providers expose. This is to promote the treatment of these data structures as immutable by consumers. This change did not cause any build errors.